### PR TITLE
Clone URL changed to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The documentation source of [Ant Design Pro](https://github.com/ant-design/ant-d
 ### Development
 
 ```bash
-$ git clone git@github.com:ant-design/ant-design-pro-site.git
+$ git clone https://github.com/ant-design/ant-design-pro-site.git
 $ cd ant-design-pro-site
 $ git submodule init
 $ git submodule update --recursive

--- a/site/theme/template/Home/Page2.jsx
+++ b/site/theme/template/Home/Page2.jsx
@@ -21,7 +21,7 @@ function Page2() {
               <FormattedMessage id="app.home.letspro" />
             </p>
             <div key="code1" className="home-code">
-              <div>$ <span>git clone</span> git@github.com:ant-design/ant-design-pro.git --depth=1</div>
+              <div>$ <span>git clone</span> https://github.com/ant-design/ant-design-pro.git --depth=1</div>
               <div>$ cd ant-design-pro</div>
               <div>$ npm install</div>
               <div>


### PR DESCRIPTION
Updated clone URL to https. Otherwise permission denied error happens.

```
$ git clone git@github.com:ant-design/ant-design-pro-site.git
Cloning into 'ant-design-pro-site'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```