### PR TITLE
fix some error

### DIFF
--- a/config/components/tool/addAntlibtoStyle.js
+++ b/config/components/tool/addAntlibtoStyle.js
@@ -41,7 +41,7 @@ const addAntlibtoStyle = function (parentsFolder) {
 
         execArray.forEach((antdLib) => {
           antdLibMap[antdLib] = true;
-          cssPathString.push(`require('${antdLib}/style/css')`);
+          cssPathString.push(`require('${antdLib}/style/css');`);
           lessPathString.push(`require('${antdLib}/style/index');`);
         });
         const stylePath = pathTool.join(__dirname, parents, 'style');
@@ -69,7 +69,7 @@ const addAntlibtoStyle = function (parentsFolder) {
   const cssPathString = [];
   const lessPathString = [];
   Object.keys(ChartsMap).forEach((antdLib) => {
-    cssPathString.push(`require('${antdLib}/style/css')`);
+    cssPathString.push(`require('${antdLib}/style/css');`);
     lessPathString.push(`require('${antdLib}/style/index');`);
   });
   // appent to css.js

--- a/config/components/tool/createStyleFolder.js
+++ b/config/components/tool/createStyleFolder.js
@@ -37,11 +37,11 @@ const createStyleFolder = function (parents) {
       less2css(stylePath);
       // add  require to css.js
       const cssJsPath = pathTool.join(stylePath, 'css.js');
-      const cssContent = `require('./${path.replace('less', 'css')}')`;
+      const cssContent = `require('./${path.replace('less', 'css')}');`;
       appentContent(cssJsPath, cssContent);
       // add  require to index.js
       const lessJsPath = pathTool.join(stylePath, 'index.js');
-      const lessContent = `require('./${path}')`;
+      const lessContent = `require('./${path}');`;
       appentContent(lessJsPath, lessContent);
     }
     if (fileStatus.isDirectory()) {

--- a/config/components/tool/megreChartsList.js
+++ b/config/components/tool/megreChartsList.js
@@ -31,7 +31,7 @@ const megreChartsList = () => {
     fs
       .readFileSync(`${chartPath}/index.less`)
       .toString()
-      .replace("@import '~antd/lib/style/themes/default.less';", '')
+      .replace('@import "../../style/themes/default.less";', '')
   );
   fs.writeFileSync(`${chartPath}/index.less`, lessPathString.join('\n'));
 };

--- a/site/theme/template/Content/ComponentDoc.jsx
+++ b/site/theme/template/Content/ComponentDoc.jsx
@@ -4,6 +4,7 @@ import DocumentTitle from 'react-document-title';
 import { FormattedMessage } from 'react-intl';
 import { Row, Col, Affix, Alert } from 'antd';
 import { getChildren } from 'jsonml.js/lib/utils';
+import { getLocalizedPathname } from '../utils';
 import Demo from './Demo';
 import EditButton from './EditButton';
 
@@ -53,6 +54,7 @@ export default class ComponentDoc extends React.PureComponent {
     const { doc, location } = props;
     const { content, meta } = doc;
     const locale = this.context.intl.locale;
+    const isZhCN = locale === 'zh-CN';
     const demos = Object.keys(props.demos).map(key => props.demos[key]);
     const { affixMode, expand } = this.state;
 
@@ -154,7 +156,7 @@ export default class ComponentDoc extends React.PureComponent {
             </pre>
             <p>
               <FormattedMessage id="app.component.refer.desc" />
-              <a href="/docs/use-components-alone">
+              <a href={getLocalizedPathname('/docs/use-components-alone', isZhCN)}>
                 <FormattedMessage id="app.component.refer.link" />
               </a>
             </p>


### PR DESCRIPTION
#### 组件发布流程

- 提取组件样式时，遗漏分号，在 require 语句后添加 ; （分号），写入到 css.js 和 index.js 文件中。
- 在组件发布流程中，合并 `Charts` 组件子文件夹样式时，应该 replace `@import "../../style/themes/default.less";`。

#### 组件文档网站

- 组件文档详情页，点击`独立使用 pro 组件` 时，根据当前语言生成链接跳转。