### PR TITLE
fix language button disapear in Mobile layout

### DIFF
--- a/site/theme/template/Layout/Header.jsx
+++ b/site/theme/template/Layout/Header.jsx
@@ -188,7 +188,10 @@ class Header extends React.Component {
 
     const isZhCN = intl.locale === 'zh-CN';
 
-    const menu = (
+    const menu = [
+      <Button onClick={this.handleLangChange} key="lang-button" block>
+        <FormattedMessage id="app.header.lang" />
+      </Button>,
       <Menu mode={menuMode} selectedKeys={[activeMenuItem]} id="nav" key="nav">
         <Menu.Item key="home">
           <Link to={getLocalizedPathname('/', isZhCN)}>
@@ -217,14 +220,16 @@ class Header extends React.Component {
             </a>
           </Menu.Item>
         )}
-      </Menu>
-    );
+      </Menu>,
+    ];
 
-    const componentSearchOption = searchOption.filter(v => v.type === 'component').map(d => (
-      <Option key={d.url}>
-        {d.title} {isZhCN && d.subTitle}
-      </Option>
-    ));
+    const componentSearchOption = searchOption
+      .filter(v => v.type === 'component')
+      .map(d => (
+        <Option key={d.url}>
+          {d.title} {isZhCN && d.subTitle}
+        </Option>
+      ));
     const docSearchOption = searchOption
       .filter(v => v.type === 'doc')
       .map(d => <Option key={d.url}>{isZhCN ? d.title : d['title-en'] || d.title}</Option>);


### PR DESCRIPTION
Refer to : [手机端没有中英文切换按钮 #247](https://github.com/ant-design/ant-design-pro-site/issues/247#issue-396160660)