### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/style.en-US.md
+++ b/docs/style.en-US.md
@@ -21,7 +21,9 @@ In the style development process, there are two prominent problems:
 In order to solve the above problems, our scaffold use CSS Modules as a modular solution. Let us have a look at how to write style in this mode.
 
 ```html
-// example.js import styles from './example.less'; export default ({title}) =>
+// example.js
+import styles from './example.less';
+export default ({title}) =>
 <div className="{styles.title}">{title}</div>
 ;
 ```


### PR DESCRIPTION
Currently part of the code in the example is commented.

-----
[View rendered docs/style.en-US.md](https://github.com/shuangq/ant-design-pro-site/blob/patch-1/docs/style.en-US.md)