### PR TITLE
Fix parameter error about menuData

### DIFF
--- a/docs/router-and-nav.zh-CN.md
+++ b/docs/router-and-nav.zh-CN.md
@@ -68,7 +68,7 @@ return (
     "path": "/dashboard",
     "name": "dashboard",
     "icon": "dashboard",
-    "routes": [
+    "children": [
       {
         "path": "/dashboard/analysis",
         "name": "analysis",


### PR DESCRIPTION
In the request menu from the server, format the data as "menuData", the submenu with routes will cause the program to error. You should use the "children" used in the code.

-----
[View rendered docs/router-and-nav.zh-CN.md](https://github.com/zongyuan-vale/ant-design-pro-site/blob/patch-1/docs/router-and-nav.zh-CN.md)