### PR TITLE
Update router-and-nav.zh-CN.md

### DIFF
--- a/docs/router-and-nav.zh-CN.md
+++ b/docs/router-and-nav.zh-CN.md
@@ -68,21 +68,18 @@ return (
     "path": "/dashboard",
     "name": "dashboard",
     "icon": "dashboard",
-    "routes": [
+    "children": [
       {
         "path": "/dashboard/analysis",
-        "name": "analysis",
-        "exact": true
+        "name": "analysis"
       },
       {
         "path": "/dashboard/monitor",
-        "name": "monitor",
-        "exact": true
+        "name": "monitor"
       },
       {
         "path": "/dashboard/workplace",
-        "name": "workplace",
-        "exact": true
+        "name": "workplace"
       }
     ]
   }


### PR DESCRIPTION
在V4使用这种方式，子菜单并未显示，于是我通过打印menuDataRender返回处理的数据，得到了菜单渲染的JSON，通过文档方式并未成功，于是修正，同时希望ant-design-pro-layout文档可以完善写

-----
[View rendered docs/router-and-nav.zh-CN.md](https://github.com/leshalv/ant-design-pro-site/blob/patch-1/docs/router-and-nav.zh-CN.md)