### PR TITLE
修复 doc: faq 中 MenuDataItem 的错误示例

### DIFF
--- a/docs/faq.en-US.md
+++ b/docs/faq.en-US.md
@@ -63,7 +63,7 @@ The above menuData definite is [MenuDataItem](https://github.com/ant-design/ant-
     path: '/dashboard',
     name: 'dashboard',
     icon: 'dashboard',
-    routes: [
+    children: [
       {
         path: '/dashboard/analysis',
         name: 'analysis',

--- a/docs/faq.zh-CN.md
+++ b/docs/faq.zh-CN.md
@@ -61,7 +61,7 @@ return (
     path: '/dashboard',
     name: 'dashboard',
     icon: 'dashboard',
-    routes: [
+    children: [
       {
         path: '/dashboard/analysis',
         name: 'analysis',


### PR DESCRIPTION
将 ```MenuDataItem``` 示例中错误的 ```routes``` 属性修改为 ```children```

-----
[View rendered docs/faq.en-US.md](https://github.com/wangtiegang/ant-design-pro-site/blob/master/docs/faq.en-US.md)
[View rendered docs/faq.zh-CN.md](https://github.com/wangtiegang/ant-design-pro-site/blob/master/docs/faq.zh-CN.md)