### PR TITLE
fix wired translation of "高德地图".

### DIFF
--- a/docs/uset-typescript.en-US.md
+++ b/docs/uset-typescript.en-US.md
@@ -75,7 +75,7 @@ class FormComponent extends React.Component<IFormComponentProps> {
 
 #### Use a library without d.ts
 
-In the actual use of some libraries and there is no relevant d.ts, this time we can directly define in the file used, taking the high German map as an example.
+In the actual use of some libraries and there is no relevant d.ts, this time we can directly define in the file used, taking the AutoNavi map as an example.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION


-----
[View rendered docs/uset-typescript.en-US.md](https://github.com/ye4241/ant-design-pro-site/blob/patch-2/docs/uset-typescript.en-US.md)