### PR TITLE
Update getting started links English links

### DIFF
--- a/docs/getting-started.en-US.md
+++ b/docs/getting-started.en-US.md
@@ -142,6 +142,6 @@ We have built-in **mock data**, **hot module reloading**, **state management**,*
 
 ## Next Steps
 
-[> Block Development](/docs/block-cn) Quickly build standard pages.
+[> Block Development](/docs/block) Quickly build standard pages.
 
-[> Traditional development mode](/docs/router-and-nav-cn), fully custom development.
+[> Traditional development mode](/docs/router-and-nav), fully custom development.


### PR DESCRIPTION
Update the gettings started English next steps links to link to the English version (was linking to Chinese version previously)

-----
[View rendered docs/getting-started.en-US.md](https://github.com/yagudaev/ant-design-pro-site/blob/patch-1/docs/getting-started.en-US.md)