### PR TITLE
doc: fix wrong pic order

### DIFF
--- a/docs/layout.zh-CN.md
+++ b/docs/layout.zh-CN.md
@@ -15,9 +15,10 @@ type: 开发
 <img src="https://gw.alipayobjects.com/zos/rmsportal/oXmyfmffJVvdbmDoGvuF.png" />
 
 - UserLayout：抽离出用于登录注册页面的通用布局
-- BlankLayout：空白的布局
 
 <img src="https://gw.alipayobjects.com/zos/rmsportal/mXsydBXvLqBVEZLMssEy.png" />
+
+- BlankLayout：空白的布局
 
 ### 如何使用 Ant Design Pro 布局
 


### PR DESCRIPTION
The img  is tended to describe the UserLayout with login, however it's under the BlankLayout

-----
[View rendered docs/layout.zh-CN.md](https://github.com/RichardStark/ant-design-pro-site/blob/patch-1/docs/layout.zh-CN.md)