### PR TITLE
Fix SVG and other banner elements not loading on mobile

### DIFF
--- a/src/components/home/Banner.jsx
+++ b/src/components/home/Banner.jsx
@@ -12,49 +12,56 @@ function Banner(props) {
   const { isMobile, location } = props;
   return (
     <div className="banner-wrapper">
-      {isMobile && (
-        <TweenOne animation={{ opacity: 1 }} className="banner-image-wrapper">
-          <div className="home-banner-image">
-            <img
-              alt="banner"
-              src="https://gw.alipayobjects.com/zos/rmsportal/rqKQOpnMxeJKngVvulsF.svg"
-              width="100%"
+      <div className='banner-top-image'>
+        {isMobile && (
+          <TweenOne animation={{ opacity: 1, type: 'to' }} className="banner-image-wrapper banner-svg-img">
+            <div className="home-banner-image" key="home-banner-image">
+              <img
+                alt="banner"
+                src="https://gw.alipayobjects.com/zos/rmsportal/rqKQOpnMxeJKngVvulsF.svg"
+                width="100%"
+                key="banner-svg-img"
+              />
+            </div>
+          </TweenOne>
+        )}
+      </div>
+      <div className='banner-text'>
+        <QueueAnim className="banner-title-wrapper" type={isMobile ? 'bottom' : 'right'}>
+          <div key="line" className="title-line-wrapper">
+            <div className="title-line" style={{ transform: 'translateX(-64px)' }} />
+          </div>
+          <h1 key="h1">ANT DESIGN PRO</h1>
+          <p key="content">
+            <FormattedMessage id="app.home.slogan" />
+          </p>
+          <div key="button" className="button-wrapper">
+            <a href="http://preview.pro.ant.design" target="_blank" rel="noopener noreferrer">
+              <Button type="primary">
+                <FormattedMessage id="app.home.preview" />
+              </Button>
+            </a>
+            <Link to={getLocalizedPathname('/docs/getting-started', isZhCN(location.pathname))}>
+              <Button style={{ margin: '0 16px' }} type="primary" ghost>
+                <FormattedMessage id="app.home.start" />
+              </Button>
+            </Link>
+            <GitHubButton
+              key="github-button"
+              type="stargazers"
+              namespace="ant-design"
+              repo="ant-design-pro"
             />
           </div>
-        </TweenOne>
-      )}
-      <QueueAnim className="banner-title-wrapper" type={isMobile ? 'bottom' : 'right'}>
-        <div key="line" className="title-line-wrapper">
-          <div className="title-line" style={{ transform: 'translateX(-64px)' }} />
-        </div>
-        <h1 key="h1">ANT DESIGN PRO</h1>
-        <p key="content">
-          <FormattedMessage id="app.home.slogan" />
-        </p>
-        <div key="button" className="button-wrapper">
-          <a href="http://preview.pro.ant.design" target="_blank" rel="noopener noreferrer">
-            <Button type="primary">
-              <FormattedMessage id="app.home.preview" />
-            </Button>
-          </a>
-          <Link to={getLocalizedPathname('/docs/getting-started', isZhCN(location.pathname))}>
-            <Button style={{ margin: '0 16px' }} type="primary" ghost>
-              <FormattedMessage id="app.home.start" />
-            </Button>
-          </Link>
-          <GitHubButton
-            key="github-button"
-            type="stargazers"
-            namespace="ant-design"
-            repo="ant-design-pro"
-          />
-        </div>
-      </QueueAnim>
-      {!isMobile && (
-        <TweenOne animation={{ opacity: 1 }} className="banner-image-wrapper">
-          <BannerSVGAnim />
-        </TweenOne>
-      )}
+        </QueueAnim>
+      </div>
+      <div className='banner-bottom-img'>
+        {!isMobile && (
+          <TweenOne animation={{ opacity: 1, type: 'to' }} className="banner-image-wrapper banner-svg-anim" key='banner-bottom-img'>
+            <BannerSVGAnim key="banner-svg" />
+          </TweenOne>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
There's a weird race condition on mobile, which prevents both the SVG animation from showing up, and the text that says "ANT DESIGN PRO" / "Out-of-box UI solution for enterprise applications" / along with the preview button and other things.

I can't tell if it's something in `TweenOne` or `QueueAnim`, or something different, but basically it's causing elements to be overwritten with attributes from another. You can see that in the gif below:

![pro-ant-design-before](https://user-images.githubusercontent.com/463175/82269288-33d7ee00-993f-11ea-8f87-e5e1cb5b5940.gif)

Notice that the SVG animation isn't loading, and the text isn't loading either (this is from the production website, on mobile).

When I inspect the HTML, I see things like `banner-title-wrapper` somehow containing the `<img src=...svg>`, which doesn't make sense -- that should have the stuff from `QueueAnim`!

After putting them in their own divs, they now seem to act properly and not overwrite each other:

![pro-ant-design-after](https://user-images.githubusercontent.com/463175/82269360-78fc2000-993f-11ea-8c34-6efdfe44533a.gif)
