### PR TITLE
fix typo in use-eslint-typescript blog.

### DIFF
--- a/blog/use-eslint-typescript.en-US.md
+++ b/blog/use-eslint-typescript.en-US.md
@@ -30,7 +30,7 @@ We publish these rules as a package  🌟🌟**umi-fabric** 🌟🌟, This lib
 The use of **umi-fabric** is very simple.
 
 ```bash
-npm install eslint @umijs/fabric -save-dev
+npm install eslint @umijs/fabric --save-dev
 ```
 
 And do the following configuration in the root directory `.eslintrc.js`.

--- a/blog/use-eslint-typescript.zh-CN.md
+++ b/blog/use-eslint-typescript.zh-CN.md
@@ -30,7 +30,7 @@ time: 2019-06-21
 **umi-fabric** 的使用非常简单。
 
 ```bash
-npm install eslint @umijs/fabric -save-dev
+npm install eslint @umijs/fabric --save-dev
 ```
 
 并且在根目录 `.eslintrc.js`  中做如下配置。


### PR DESCRIPTION
Fix the typo of `npm install` command:
```
- npm install eslint @umijs/fabric -save-dev
+ npm install eslint @umijs/fabric --save-dev
```