### PR TITLE
Update authority-management.zh-CN.md and authority-management.en-US.md

### DIFF
--- a/docs/authority-management.en-US.md
+++ b/docs/authority-management.en-US.md
@@ -68,6 +68,18 @@ const PageA = (props) => {
 
 You can get the permission definition through `useAccess` hook, in addition, we have built-in `Access` component for displaying and hiding control of the elements in the Component.
 
+`Access` component only can used in hook component, if you want to use it at class component, you can use custom component to define it.4
+
+For example:
+
+```react
+const Button=()=>{
+   const  access =  useXX();
+   // do anything you want
+   return <Button/>
+}
+```
+
 ## 3. Permission control for routing and menus
 
 If you need to control the routing and the menu on the left side of the page, you can directly add the attributes related to the permission control to the original basic configuration of the route. For this purpose, **[@umijs/plugin-layout](https://umijs.org/plugins/plugin-layout) is needed）**.

--- a/docs/authority-management.zh-CN.md
+++ b/docs/authority-management.zh-CN.md
@@ -70,6 +70,18 @@ const PageA = (props) => {
 
 你可以通过 `useAccess` hook 来获取权限定义，另外我们内置了 `Access`  组件用于页面的元素显示和隐藏的控制。
 
+ `Access`  组件只有hooks的用法，如果需要在class组件中使用的话，可以把需要用到权限的拆分为function。
+
+示例如下：
+
+```react
+const Button=()=>{
+   const  access =  useXX();
+   // 权限处理
+   return <Button/>
+}
+```
+
 ## 三、路由和菜单的权限控制
 
 如果需要对路由还有菜单进行权限控制，可以直接在路由上原有基础配置上加上权限控制相关的属性，即可快速实现路由和菜单的权限控制。**（前提需要使用最佳实践的 Layout 方案 - [@alipay/umi-plugin-layout](https://umijs.org/plugins/plugin-layout) ）**。


### PR DESCRIPTION
V5版的Access组件只有hook的用法，文档里添加了一点提示，希望能帮助到更多人。

---

Access component only can use in hook component, added some tips.

-----
[View rendered docs/authority-management.en-US.md](https://github.com/wenslo/ant-design-pro-site/blob/v5/docs/authority-management.en-US.md)
[View rendered docs/authority-management.zh-CN.md](https://github.com/wenslo/ant-design-pro-site/blob/v5/docs/authority-management.zh-CN.md)