### PR TITLE
V5

### DIFF
--- a/docs/authority-management.en-US.md
+++ b/docs/authority-management.en-US.md
@@ -68,6 +68,18 @@ const PageA = (props) => {
 
 You can get the permission definition through `useAccess` hook, in addition, we have built-in `Access` component for displaying and hiding control of the elements in the Component.
 
+`Access` component only can used in hook component, if you want to use it at class component, you can use custom component to define it.4
+
+For example:
+
+```react
+const Button=()=>{
+   const  access =  useXX();
+   // do anything you want
+   return <Button/>
+}
+```
+
 ## 3. Permission control for routing and menus
 
 If you need to control the routing and the menu on the left side of the page, you can directly add the attributes related to the permission control to the original basic configuration of the route. For this purpose, **[@umijs/plugin-layout](https://umijs.org/plugins/plugin-layout) is needed）**.

--- a/docs/authority-management.zh-CN.md
+++ b/docs/authority-management.zh-CN.md
@@ -70,6 +70,18 @@ const PageA = (props) => {
 
 你可以通过 `useAccess` hook 来获取权限定义，另外我们内置了 `Access`  组件用于页面的元素显示和隐藏的控制。
 
+ `Access`  组件只有hooks的用法，如果需要在class组件中使用的话，可以把需要用到权限的拆分为function。
+
+示例如下：
+
+```react
+const Button=()=>{
+   const  access =  useXX();
+   // 权限处理
+   return <Button/>
+}
+```
+
 ## 三、路由和菜单的权限控制
 
 如果需要对路由还有菜单进行权限控制，可以直接在路由上原有基础配置上加上权限控制相关的属性，即可快速实现路由和菜单的权限控制。**（前提需要使用最佳实践的 Layout 方案 - [@alipay/umi-plugin-layout](https://umijs.org/plugins/plugin-layout) ）**。

--- a/docs/layout.en-US.md
+++ b/docs/layout.en-US.md
@@ -261,6 +261,41 @@ export default [
 ];
 ```
 
+### Modification of menu layout mode
+
+Sometimes our menu may display at top, left or left and top either, This can be achieved by changing `layout` at defaultSettings.js.
+
+- top  Display at top
+- side Display at left side
+- mix  Display at left and top either，by the way，when the layout mode is `mix`， we need add `splitMenus: true` at defaultSettings.js
+
+```js
+// config/defaultSettings.ts
+export default {
+  layout: 'mix',
+  splitMenus: true,
+} 
+```
+
+Tips: When the layout mode is `mix`，click the first menu, page cannot route they first children menu page, you can add `redirect` at route.
+
+```json
+[
+  {
+    "path": "/test/list",
+    "component": "./test/list"
+  },
+  {
+    "path": "/test/list/testAdd",
+    "component": "./test/list/testAdd"
+  },
+  {
+    "redirect": "./test/list"
+  }
+]
+
+```
+
 ## Other
 
 ### Dynamically add routes

--- a/docs/layout.zh-CN.md
+++ b/docs/layout.zh-CN.md
@@ -275,6 +275,42 @@ export default [
 ];
 ```
 
+### 菜单布局展示方式的修改
+
+有时菜单可能需要于顶部显示，左侧显示，或者顶部显示一级菜单，左侧显示二三级菜单。我们可以修改defaultSettings中的layout的配置来决定菜单的展示方式。
+
+- top 菜单于顶部展示
+- side 菜单于左侧展示
+- mix 菜单于顶部和左侧混合展示，需要注意，当mix模式时，需要添加`splitMenus: true`，顶部才可以正确展示一级菜单
+
+```js
+// config/defaultSettings.ts
+export default {
+  layout: 'mix',
+  splitMenus: true,
+} 
+```
+
+同时，当使用mix模式后，点击一级菜单，并不会直接定位到第一个子级菜单页面，而是会呈现空白页面，需要于配置中设置一下redirect的地址
+
+```json
+[
+  {
+    "path": "/test/list",
+    "component": "./test/list"
+  },
+  {
+    "path": "/test/list/testAdd",
+    "component": "./test/list/testAdd"
+  },
+  {
+    "redirect": "./test/list"
+  }
+]
+
+```
+
+
 ## 其他
 
 ### 动态新增路由


### PR DESCRIPTION
Menu display mode tips added
----------
菜单显示方式配置文档添加

-----
[View rendered docs/authority-management.en-US.md](https://github.com/wenslo/ant-design-pro-site/blob/v5/docs/authority-management.en-US.md)
[View rendered docs/authority-management.zh-CN.md](https://github.com/wenslo/ant-design-pro-site/blob/v5/docs/authority-management.zh-CN.md)
[View rendered docs/layout.en-US.md](https://github.com/wenslo/ant-design-pro-site/blob/v5/docs/layout.en-US.md)
[View rendered docs/layout.zh-CN.md](https://github.com/wenslo/ant-design-pro-site/blob/v5/docs/layout.zh-CN.md)