### PR TITLE
菜单获取重写

### DIFF
--- a/docs/advanced-menu.en-US.md
+++ b/docs/advanced-menu.en-US.md
@@ -4,7 +4,7 @@ title: Advanced menu
 type: Advanced Usage
 ---
 
-Pro Intermediate will re-read the config / config.tsx Intermediate Route and configure it as the ProLayout menu data to generate the menu, and cooperate with [plugin-access`] (https://umijs.org/plugins/plugin-access). It is convenient to manage the authority of this menu. This mode can meet most of the needs, but the complexity of the business is always there, and sometimes it requires some advanced usage.
+By default, Pro will read the routes configuration in `config/config.tsx` as the menu data of ProLayout to generate the menu. If you cooperate with [`plugin-access`](https://umijs.org/plugins/plugin-access), you can easily manage the authority of the menu. This mode can meet most of the needs, but the complexity of the business is always there, and sometimes it requires some advanced usage.
 
 ## Request the menu from the server
 
@@ -29,7 +29,7 @@ export const layout = async ({
 };
 ```
 
-In this way, we can use `initialState`to complete the update of the menu, we need to write the following code in `src/app.tsx`:
+In this way, we can use `initialState` to complete the update of the menu, we need to write the following code in `src/app.tsx`:
 
 ```tsx
 export async function getInitialState(): Promise<{
@@ -51,9 +51,11 @@ export async function getInitialState(): Promise<{
 }
 ```
 
-If we need to reset the menu on the page, we can update it through `useModel`. The code looks like this:
+If we need to reset the menu on the page, we can update it through [`useModel`](https://umijs.org/plugins/plugin-initial-state#usemodel). The code looks like this:
 
 ```tsx
+import { useModel } from 'umi';
+
 const { initialState, setInitialState } = useModel('@@initialState');
 
 const fetchMenuData = async () => {
@@ -65,17 +67,15 @@ const fetchMenuData = async () => {
       },
     },
   });
-  const menuData = await getMenuData();
 
-  setInitialState({
-    ...initialState,
-    menuData,
-    settings: {
-      menu: {
-        loading: false,
-      },
-    },
-  });
+  const menuData = await initialState?.fetchMenu?.();
+
+  if (menuData) {
+    setInitialState({
+      ...initialState,
+      menuData,
+    });
+  }
 };
 ```
 

--- a/docs/advanced-menu.en-US.md
+++ b/docs/advanced-menu.en-US.md
@@ -11,12 +11,14 @@ Pro Intermediate will re-read the config / config.tsx Intermediate Route and con
 In some cases, hard-coded menu data may not meet our needs. Pro also provides corresponding solutions for remote menu data requests. Here we need to use two APIs to complete the configuration. `menuDataRender` can customize the data format, `menu.loading` can make the menu display in a loading state.
 
 ```tsx
+import type { MenuDataItem } from '@ant-design/pro-layout';
+
 export const layout = async ({
   initialState,
 }: {
   initialState: {
     settings?: LayoutSettings;
-    menuData: Promise<BasicLayoutProps>;
+    menuData: MenuDataItem[];
     currentUser?: API.CurrentUser;
   };
 }): BasicLayoutProps => {

--- a/docs/advanced-menu.zh-CN.md
+++ b/docs/advanced-menu.zh-CN.md
@@ -53,9 +53,11 @@ export async function getInitialState(): Promise<{
 }
 ```
 
-如果我们需要在页面中的重新设置菜单，我们就可以通过 `useModel` 来进行更新。代码看起来是这样的：
+如果我们需要在页面中的重新设置菜单，我们就可以通过 [`useModel`](https://umijs.org/plugins/plugin-initial-state#usemodel) 来进行更新。代码看起来是这样的：
 
 ```tsx
+import { useModel } from 'umi';
+
 const { initialState, setInitialState } = useModel('@@initialState');
 
 const fetchMenuData = async () => {
@@ -67,17 +69,15 @@ const fetchMenuData = async () => {
       },
     },
   });
-  const menuData = await getMenuData();
 
-  setInitialState({
-    ...initialState,
-    menuData,
-    settings: {
-      menu: {
-        loading: false,
-      },
-    },
-  });
+  const menuData = await initialState?.fetchMenu?.();
+
+  if (menuData) {
+    setInitialState({
+      ...initialState,
+      menuData,
+    });
+  }
 };
 ```
 

--- a/docs/advanced-menu.zh-CN.md
+++ b/docs/advanced-menu.zh-CN.md
@@ -13,12 +13,14 @@ Pro 中默认会读取 `config/config.tsx` 中的 routes 配置作为 ProLayout 
 具体的代码实现如下，我们可以在 `src/app.tsx` 定义 layout 对象，并且导出。
 
 ```tsx
+import type { MenuDataItem } from '@ant-design/pro-layout';
+
 export const layout = async ({
   initialState,
 }: {
   initialState: {
     settings?: LayoutSettings;
-    menuData: Promise<BasicLayoutProps>;
+    menuData: MenuDataItem[];
     currentUser?: API.CurrentUser;
   };
 }): BasicLayoutProps => {


### PR DESCRIPTION
实测menu的loading会被自动管理，所以删掉了无用语句。另外修改了一些中英文文本。

-----
[View rendered docs/advanced-menu.en-US.md](https://github.com/aspirantzhang/ant-design-pro-site/blob/v5/docs/advanced-menu.en-US.md)
[View rendered docs/advanced-menu.zh-CN.md](https://github.com/aspirantzhang/ant-design-pro-site/blob/v5/docs/advanced-menu.zh-CN.md)