### PR TITLE
docs: fix typo, change url

### DIFF
--- a/docs/getting-started.en-US.md
+++ b/docs/getting-started.en-US.md
@@ -8,7 +8,7 @@ Ant Design Pro is a production-ready solution for admin interfaces. Built on the
 
 ## Tips before development
 
-Ant Design Pro is a front-end scaffolding. By default, readers have already understood some basic front-end knowledge, and understand umi and Ant Design. If you are a pure novice, it is recommended to read [Beginner's Guide](/docs/) getting-started-cn). Sharpen the knife and chop wood by mistake. Knowing some basic knowledge can make the learning curve smoother.
+Ant Design Pro is a front-end scaffolding. By default, readers have already understood some basic front-end knowledge, and understand umi and Ant Design. If you are a pure novice, it is recommended to read [Beginner's Need to know](/docs/introduction-cn). Sharpen the knife and chop wood by mistake. Knowing some basic knowledge can make the learning curve smoother.
 
 ## Init
 

--- a/docs/getting-started.en-US.md
+++ b/docs/getting-started.en-US.md
@@ -8,7 +8,7 @@ Ant Design Pro is a production-ready solution for admin interfaces. Built on the
 
 ## Tips before development
 
-Ant Design Pro is a front-end scaffolding. By default, readers have already understood some basic front-end knowledge, and understand umi and Ant Design. If you are a pure novice, it is recommended to read [Beginner's Need to know](/docs/introduction-cn). Sharpen the knife and chop wood by mistake. Knowing some basic knowledge can make the learning curve smoother.
+Ant Design Pro is a front-end scaffolding. By default, readers have already understood some basic front-end knowledge, and understand umi and Ant Design. If you are a pure novice, it is recommended to read [Beginner's Need to know](/docs/introduction). Sharpen the knife and chop wood by mistake. Knowing some basic knowledge can make the learning curve smoother.
 
 ## Init
 

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -8,7 +8,7 @@ Ant Design Pro 是基于 Ant Design 和 umi 的封装的一整套企业级中后
 
 ## 开发前的输入
 
-Ant Design Pro 作为一个前端脚手架，默认读者已经懂了一些前端的基础知识，并且了解 umi 和 Ant Design, 如果你是纯粹的新手，第一次来跑项目建议读一下 [新手入门](/docs/getting-started-cn)。磨刀不误砍柴工，了解一些基础知识可以让学习曲线更加平滑。
+Ant Design Pro 作为一个前端脚手架，默认读者已经懂了一些前端的基础知识，并且了解 umi 和 Ant Design, 如果你是纯粹的新手，第一次来跑项目建议读一下 [新手需知](/docs/introduction-cn)。磨刀不误砍柴工，了解一些基础知识可以让学习曲线更加平滑。
 
 ## 准备工作
 


### PR DESCRIPTION
修改链接和英文文档的 typo
<img width="1144" alt="iShot2021-05-08 07 50 38" src="https://user-images.githubusercontent.com/16836801/117518487-78d2b580-afd2-11eb-87d8-1096afdaa4fe.png">


-----
[View rendered docs/getting-started.en-US.md](https://github.com/Ivocin/ant-design-pro-site/blob/v5-ivocin/docs/getting-started.en-US.md)
[View rendered docs/getting-started.zh-CN.md](https://github.com/Ivocin/ant-design-pro-site/blob/v5-ivocin/docs/getting-started.zh-CN.md)