### PR TITLE
docs: fix some contents in docs

### DIFF
--- a/docs/docs/adding-images-fonts-and-files.en-US.md
+++ b/docs/docs/adding-images-fonts-and-files.en-US.md
@@ -22,7 +22,7 @@ console.log(logo); //logo.84287d09.png
 return <Image src={logo} />;
 ```
 
-In order to speed up the loading speed and reduce network requests, we will convert less than 1000k into [base64] (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs), this version Only valid for pictures.
+In order to speed up the loading speed and reduce network requests, we will convert less than 1000k into [base64](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs), this version Only valid for pictures.
 
 You may notice that the final generated `logo.png` will become `logo.84287d09.png`. This is to ensure that the image will be updated every time the version is released. If the name is not changed, it will hit the cache of `logo.png` , You can use import without worrying about caching.
 
@@ -37,7 +37,7 @@ When compiling, all public will be moved to dist without any processing. Be sure
 
 ## Add SVG
 
-svg is a special tag, in order to facilitate management, we recommend that you convert it into a component to use. There are many [tools] (https://github.com/sairion/svg-inline-react) for converting svg into react components on the Internet. The final result is this:
+svg is a special tag, in order to facilitate management, we recommend that you convert it into a component to use. There are many [tools](https://github.com/sairion/svg-inline-react) for converting svg into react components on the Internet. The final result is this:
 
 ```tsx | pure
 return (

--- a/docs/docs/request.en-US.md
+++ b/docs/docs/request.en-US.md
@@ -58,7 +58,7 @@ The first argument to useRequest takes a function that returns a Promise, which 
 
 The data returned by the Hook is the data field in the actual JSON data returned by the backend, which is easy to use (of course you can also modify it through configuration). See its [API documentation](https://umijs.org/plugins/plugin-request#userequest) for more on the use of useRequest.
 
-<! -- ### Middleware -->
+<!-- ### Middleware -->
 
 ## Middleware & Interceptors
 

--- a/docs/docs/simple-model.en-US.md
+++ b/docs/docs/simple-model.en-US.md
@@ -46,7 +46,7 @@ export default () => {
 
 ### 2. Using the Model
 
-To use the model in code, you need to export useModel from umi. useModel is a React Custom Hook that can accept 1-2 parameters. The easyst usage scenario is as follows:
+To use the model in code, you need to export useModel from umi. useModel is a React Custom Hook that can accept 1-2 parameters. The easiest usage scenario is as follows:
 
 ```
 import { useModel } from 'umi';

--- a/docs/docs/typeScript.en-US.md
+++ b/docs/docs/typeScript.en-US.md
@@ -255,8 +255,8 @@ const rowSelection: TableRowSelection = {
 
 If we use the function component, it may report an error that ref cannot be found. At this time, we need to use `React.forwardRef`, but it should be noted that the type must also be modified accordingly.
 
-```tsx | pure
--React.FC<CategorySelectProps>
+```diff
+- React.FC<CategorySelectProps>
 + React.ForwardRefRenderFunction<HTMLElement, CategorySelectProps>
 ```
 


### PR DESCRIPTION
Hi, I fixed some contents such as : 

1. Links

before:
![image](https://user-images.githubusercontent.com/43397636/127705406-3acc74df-bd74-4f10-821c-d7ac1539f849.png)

after:
![image](https://user-images.githubusercontent.com/43397636/127705485-a46fd030-42c4-428a-8fe6-b722f9fe106d.png)

<hr />

2. Comment (should be properly commented)

before:
![image](https://user-images.githubusercontent.com/43397636/127705649-78c6435f-5b1b-41f4-b4ec-9f100f6cfa63.png)

after (it is hidden now) : 
![image](https://user-images.githubusercontent.com/43397636/127705730-be6ae38a-250f-4645-a8b1-e0ae3c10b4e3.png)

<hr />

3. Show Code Difference

before:
![image](https://user-images.githubusercontent.com/43397636/127705873-7102c53d-6ca3-40af-a7e3-a9d563b31402.png)

after:
![image](https://user-images.githubusercontent.com/43397636/127705904-1f1f94f4-2cf8-4e59-b904-90c0fc935526.png)

Any feedback and suggestions are appreciated!

-----
[View rendered docs/docs/adding-images-fonts-and-files.en-US.md](https://github.com/kevinadhiguna/ant-design-pro-site/blob/patch/easyModel/docs/docs/adding-images-fonts-and-files.en-US.md)
[View rendered docs/docs/request.en-US.md](https://github.com/kevinadhiguna/ant-design-pro-site/blob/patch/easyModel/docs/docs/request.en-US.md)
[View rendered docs/docs/simple-model.en-US.md](https://github.com/kevinadhiguna/ant-design-pro-site/blob/patch/easyModel/docs/docs/simple-model.en-US.md)
[View rendered docs/docs/typeScript.en-US.md](https://github.com/kevinadhiguna/ant-design-pro-site/blob/patch/easyModel/docs/docs/typeScript.en-US.md)