### PR TITLE
Update layout.en-US.md

### DIFF
--- a/docs/docs/layout.en-US.md
+++ b/docs/docs/layout.en-US.md
@@ -49,7 +49,7 @@ export const config = defineConfig({
 
 We can configure the menu in the route to determine whether the current route will be rendered in the menu. [Detailed configuration instructions](https://umijs.org/plugins/plugin-layout#menu)
 
-- hen you do not need to display in the menu, you can configure hideInMenu on the route or delete the menu-related configuration;
+- When you do not need to display in the menu, you can configure hideInMenu on the route or delete the menu-related configuration;
 - When you don't need to show children, you can configure hideChildrenInMenu on the route;
 - When you do not need to show yourself, only show children, you can configure flatMenu on the route;
 - If the menu is not configured, and the name is not configured, the route will not appear in the sidebar.


### PR DESCRIPTION
Just a spelling update(fix) in the ProLayout docs. I was reading the docs for an issue I was trying to solve when I came across this typo. :)

-----
[View rendered docs/docs/layout.en-US.md](https://github.com/anjali-001/ant-design-pro-site/blob/patch-1/docs/docs/layout.en-US.md)