### PR TITLE
修改 标题和加载页 中的提示错误

### DIFF
--- a/docs/docs/title-landing.zh-CN.md
+++ b/docs/docs/title-landing.zh-CN.md
@@ -20,7 +20,7 @@ const settings: LayoutSettings & {
   pwa?: boolean;
   logo?: string;
 } = {
-  // 修改右上角的 logo
+  // 修改左上角的 logo
   logo: 'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',
   // 设置标题的 title
   title: 'Ant Design Pro',


### PR DESCRIPTION
logo是在左上角，不是右上角

-----
[View rendered docs/docs/title-landing.zh-CN.md](https://github.com/kibuniverse/ant-design-pro-site/blob/patch-1/docs/docs/title-landing.zh-CN.md)