### PR TITLE
Update deploy.md

### DIFF
--- a/docs/docs/deploy.en-US.md
+++ b/docs/docs/deploy.en-US.md
@@ -66,7 +66,7 @@ server {
 
     location / {
         # 用于配合 browserHistory使用
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/index.html /index.html;
 
         # 如果有资源，建议使用 https + http2，配合按需加载可以获得更好的体验
         # rewrite ^/(.*)$ https://preview.pro.ant.design/$1 permanent;
@@ -89,7 +89,7 @@ server {
 
   location / {
         # 用于配合 browserHistory使用
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/index.html /index.html;
 
   }
   location /api {

--- a/docs/docs/deploy.zh-CN.md
+++ b/docs/docs/deploy.zh-CN.md
@@ -64,7 +64,7 @@ server {
 
     location / {
         # 用于配合 browserHistory使用
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/index.html /index.html;
 
         # 如果有资源，建议使用 https + http2，配合按需加载可以获得更好的体验
         # rewrite ^/(.*)$ https://preview.pro.ant.design/$1 permanent;
@@ -87,7 +87,7 @@ server {
 
   location / {
         # 用于配合 browserHistory使用
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/index.html /index.html;
 
   }
   location /api {


### PR DESCRIPTION
旧配置存在问题：游览器链接http://www.example.com/a/b刷新后会触发HTTP301错误，重定向到http://www.example.com/a/b/

-----
[View rendered docs/docs/deploy.en-US.md](https://github.com/guogeer/ant-design-pro-site/blob/master/docs/docs/deploy.en-US.md)
[View rendered docs/docs/deploy.zh-CN.md](https://github.com/guogeer/ant-design-pro-site/blob/master/docs/docs/deploy.zh-CN.md)