### PR TITLE
Update getting-started.zh-CN.md

### DIFF
--- a/docs/docs/getting-started.zh-CN.md
+++ b/docs/docs/getting-started.zh-CN.md
@@ -75,7 +75,7 @@ yarn create umi myapp
 安装依赖：
 
 ```shell
-$ cd myapp && tyarn
+$ cd myapp && yarn
 // 或
 $ cd myapp && npm install
 ```


### PR DESCRIPTION
A small mistake.
Change `tyarn` to `yarn`.

-----
[View rendered docs/docs/getting-started.zh-CN.md](https://github.com/zengxingchen/ant-design-pro-site/blob/patch-1/docs/docs/getting-started.zh-CN.md)