### PR TITLE
fix: 修复首页动画抖动的问题

### DIFF
--- a/.dumi/theme/home/image/index.js
+++ b/.dumi/theme/home/image/index.js
@@ -255,7 +255,8 @@ export default () => {
             />
           </div>
         </div>
-        <div className="con_right" onMouseEnter={handleOver} onMouseLeave={handleOut}>
+        <div className="con_right">
+          <div className="hover_layer" onMouseEnter={handleOver} onMouseLeave={handleOut}></div>
           <div ref={aniBg} className="animate">
             <ul ref={btn} className="ani_btn">
               <li /> <li /> <li />

--- a/.dumi/theme/home/image/index.less
+++ b/.dumi/theme/home/image/index.less
@@ -171,6 +171,19 @@ html[data-darkreader-scheme='dark'] {
       }
     }
     .con_right {
+      position: relative;
+      .hover_layer {
+        z-index: 10;
+        width: 480px;
+        height: 320px;
+        position: absolute;
+        &:hover {
+          & + .animate {
+            box-shadow: 4px 4px 32px rgba(204, 218, 233, 0.2);
+            background-image: url(../assets/background_hover.svg);
+          }
+        }
+      }
       width: 40%;
       @media screen and (max-width: 768px) {
         display: none;
@@ -179,10 +192,6 @@ html[data-darkreader-scheme='dark'] {
       justify-content: center;
       align-items: center;
       // border: 1px solid red;
-      &:hover .animate {
-        box-shadow: 4px 4px 32px rgba(204, 218, 233, 0.2);
-        background-image: url(../assets/background_hover.svg);
-      }
     }
   }
 }


### PR DESCRIPTION
鼠标进入动画区域时，当鼠标停留在区域边界时，动画会抖动，修复方式为新增一个div，覆盖在原有的div上面，并且把鼠标的hover事件绑定在新的div上