### PR TITLE
fix: 修复文档链接

### DIFF
--- a/docs/config/config.en-US.md
+++ b/docs/config/config.en-US.md
@@ -184,7 +184,7 @@ If you enable `exportStatic`, html files will be output for each route.
 
 Contains the following attributes:
 
--htmlSuffix, enable the `.html` suffix. -dynamicRoot, deploy to any path. -extraRoutePaths, generate additional route pages, see [Pre-rendering dynamic routing](/zh-CN/docs/ssr#Pre-rendering dynamic routing)
+-htmlSuffix, enable the `.html` suffix. -dynamicRoot, deploy to any path. -extraRoutePaths, generate additional route pages, see [Pre-rendering dynamic routing](https://v3.umijs.org/docs/ssr#%E9%A2%84%E6%B8%B2%E6%9F%93%E5%8A%A8%E6%80%81%E8%B7%AF%E7%94%B1)
 
 ## externals
 
@@ -356,7 +356,7 @@ export default defineConfig({
 
 Configure routing.
 
-umi's routing is implemented based on [react-router@5](https://reacttraining.com/react-router/web/guides/quick-start), and the configuration is basically the same as that of react-router, see [Routing Configuration](. /docs/routing) chapter.
+umi's routing is implemented based on [react-router@5](https://reacttraining.com/react-router/web/guides/quick-start), and the configuration is basically the same as that of react-router, see [Routing Configuration](https://v3.umijs.org/docs/routing) chapter.
 
 such as:
 

--- a/docs/config/config.zh-CN.md
+++ b/docs/config/config.zh-CN.md
@@ -199,7 +199,7 @@ export default {
 
 - htmlSuffix，启用 `.html` 后缀。
 - dynamicRoot，部署到任意路径。
-- extraRoutePaths，生成额外的路径页面，用法和场景见 [预渲染动态路由](/zh-CN/docs/ssr#预渲染动态路由)
+- extraRoutePaths，生成额外的路径页面，用法和场景见 [预渲染动态路由](https://v3.umijs.org/zh-CN/docs/ssr#%E9%A2%84%E6%B8%B2%E6%9F%93%E5%8A%A8%E6%80%81%E8%B7%AF%E7%94%B1)
 
 ## externals
 
@@ -381,7 +381,7 @@ export default defineConfig({
 
 配置路由。
 
-umi 的路由基于 [react-router@5](https://reacttraining.com/react-router/web/guides/quick-start) 实现，配置和 react-router 基本一致，详见[路由配置](./docs/routing)章节。
+umi 的路由基于 [react-router@5](https://reacttraining.com/react-router/web/guides/quick-start) 实现，配置和 react-router 基本一致，详见[路由配置](https://v3.umijs.org/zh-CN/docs/routing)章节。
 
 比如：
 


### PR DESCRIPTION
修复两处中英文文档链接

-----
[View rendered docs/config/config.en-US.md](https://github.com/wangmeijian/ant-design-pro-site/blob/hotfix/docs/docs/config/config.en-US.md)
[View rendered docs/config/config.zh-CN.md](https://github.com/wangmeijian/ant-design-pro-site/blob/hotfix/docs/docs/config/config.zh-CN.md)