### PR TITLE
fix: Broken links on i18n.en-US.md

### DIFF
--- a/docs/docs/i18n.en-US.md
+++ b/docs/docs/i18n.en-US.md
@@ -11,7 +11,7 @@ nav:
 
 ### Getting Started
 
-Pro implements globalization through the umi plugin [@umijs/plugin-locale](https://github.com/umijs/@umijs/plugin-locale) and is enabled by default. `@umijs/plugin-locale` convention Introduces the corresponding js in src/locales, such as en-US.ts and zh-CN.ts, And do the following configuration in `config/config.ts`:
+Pro implements globalization through the umi plugin [@umijs/plugin-locale](https://github.com/umijs/umi/blob/master/packages/plugins/src/locale.ts) and is enabled by default. `@umijs/plugin-locale` convention Introduces the corresponding js in src/locales, such as en-US.ts and zh-CN.ts, And do the following configuration in `config/config.ts`:
 
 ```tsx | pure
 plugins:[
@@ -25,7 +25,7 @@ plugins:[
 ]
 ```
 
-I am happy to use the function of globalization. See [config](https://umijs.org/plugins/plugin-locale) for detailed configuration)。
+I am happy to use the function of globalization. See [config](https://umijs.org/docs/max/i18n) for detailed configuration)。
 
 `@umijs/plugin-locale` encapsulates [react-intl](https://github.com/yahoo/react-intl), api is basically the same as `react-intl`, and is more convenient to package. All apis are as follows:
 
@@ -96,7 +96,7 @@ class SelectLang extends React.Component {
 }
 ```
 
-More advanced usage can be found in [plugin-locale](https://umijs.org/plugins/plugin-locale).
+More advanced usage can be found in [plugin-locale](https://umijs.org/docs/max/i18n).
 
 ### Remove globalization
 

--- a/docs/docs/i18n.en-US.md
+++ b/docs/docs/i18n.en-US.md
@@ -25,7 +25,7 @@ plugins:[
 ]
 ```
 
-I am happy to use the function of globalization. See [config](https://umijs.org/docs/max/i18n) for detailed configuration)。
+I am happy to use the function of globalization. See [config](https://umijs.org/en-US/docs/max/i18n) for detailed configuration)。
 
 `@umijs/plugin-locale` encapsulates [react-intl](https://github.com/yahoo/react-intl), api is basically the same as `react-intl`, and is more convenient to package. All apis are as follows:
 
@@ -96,7 +96,7 @@ class SelectLang extends React.Component {
 }
 ```
 
-More advanced usage can be found in [plugin-locale](https://umijs.org/docs/max/i18n).
+More advanced usage can be found in [plugin-locale](https://umijs.org/en-US/docs/max/i18n).
 
 ### Remove globalization
 


### PR DESCRIPTION
- Fixed the broken links to the umi locale information page
- Fixed the broken GitHub link to the locale plugin