### PR TITLE
fix: dashboard make  path error

### DIFF
--- a/.dumi/theme/dashboard.tsx
+++ b/.dumi/theme/dashboard.tsx
@@ -52,9 +52,10 @@ const Dashboard: React.FC<{ menuData: IMenuItem[] }> = ({ menuData }) => {
                 title={group.title}
               >
                 {components.map((component) => {
-                  const url = `${component.path
-                    .replace(/(\/index)?((\.zh-CN)|(\.en-us))?\.md$/i, '')
-                    .toLowerCase()}/`;
+                  const url = `${component.path?.replace(
+                    /(\/index)?((\.zh-CN)|(\.en-us))?\.md$/i,
+                    '',
+                  )}/`;
                   return (
                     <a href={url} key={url}>
                       <Space


### PR DESCRIPTION
在文档总览 https://pro.ant.design/zh-CN/docs/overview 页面的链接，被小写了。
导致跳转后的页面 国际化出现问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了当组件路径不存在时可能导致的报错问题，并保留了路径的原始大小写显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->